### PR TITLE
Handle download interruptions with resume support

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/models/DownloadItem.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/models/DownloadItem.kt
@@ -25,7 +25,10 @@ data class DownloadItem(
   val isInternalStorage get() = localFolder.id.startsWith("internal-")
 
   @get:JsonIgnore
-  val isDownloadFinished get() = !downloadItemParts.any { !it.completed || it.isMoving }
+  val hasFailures get() = downloadItemParts.any { it.failed }
+
+  val isDownloadFinished
+    get() = downloadItemParts.all { it.completed && !it.failed && !it.isMoving }
 
   @JsonIgnore
   fun getNextDownloadItemParts(limit:Int): MutableList<DownloadItemPart> {
@@ -33,7 +36,7 @@ data class DownloadItem(
     if (limit == 0) return itemParts
 
     for (it in downloadItemParts) {
-      if (!it.completed && it.downloadId == null) {
+      if (!it.completed && it.downloadId == null && !it.failed) {
         itemParts.add(it)
         if (itemParts.size >= limit) break
       }

--- a/components/widgets/DownloadProgressIndicator.vue
+++ b/components/widgets/DownloadProgressIndicator.vue
@@ -12,7 +12,8 @@ export default {
     return {
       downloadItemListener: null,
       completeListener: null,
-      itemPartUpdateListener: null
+      itemPartUpdateListener: null,
+      failureListener: null
     }
   },
   computed: {
@@ -69,24 +70,51 @@ export default {
     onDownloadItem(downloadItem) {
       console.log('DownloadProgressIndicator onDownloadItem', JSON.stringify(downloadItem))
 
-      downloadItem.itemProgress = 0
+      if (typeof downloadItem.itemProgress !== 'number') {
+        downloadItem.itemProgress = 0
+      }
       downloadItem.episodes = downloadItem.downloadItemParts.filter((dip) => dip.episode).map((dip) => dip.episode)
 
       this.$store.commit('globals/addUpdateItemDownload', downloadItem)
     },
     onDownloadItemPartUpdate(itemPart) {
       this.$store.commit('globals/updateDownloadItemPart', itemPart)
+    },
+    onDownloadFailed(data) {
+      if (!data) return
+      if (Array.isArray(data.parts)) {
+        data.parts.forEach((part) => this.$store.commit('globals/updateDownloadItemPart', part))
+      }
+
+      const downloadItemId = data.downloadItemId || data.libraryItemId
+      const existing = this.downloadItems.find((item) => item.id === downloadItemId || item.libraryItemId === data.libraryItemId)
+      const title = data.itemTitle || existing?.itemTitle || existing?.media?.metadata?.title || this.$strings.LabelDownload
+      const message = this.$getString('ToastDownloadInterrupted', [title]) || this.$strings.ToastDownloadInterrupted
+      this.$toast.error(message)
+    },
+    async syncActiveDownloads() {
+      try {
+        const queue = await AbsDownloader.getDownloadQueue()
+        if (queue && Array.isArray(queue.items)) {
+          queue.items.forEach((item) => this.onDownloadItem(item))
+        }
+      } catch (error) {
+        console.error('Failed to load active downloads', error)
+      }
     }
   },
   async mounted() {
+    this.syncActiveDownloads()
     this.downloadItemListener = await AbsDownloader.addListener('onDownloadItem', (data) => this.onDownloadItem(data))
     this.itemPartUpdateListener = await AbsDownloader.addListener('onDownloadItemPartUpdate', (data) => this.onDownloadItemPartUpdate(data))
     this.completeListener = await AbsDownloader.addListener('onItemDownloadComplete', (data) => this.onItemDownloadComplete(data))
+    this.failureListener = await AbsDownloader.addListener('onDownloadItemFailed', (data) => this.onDownloadFailed(data))
   },
   beforeDestroy() {
     this.downloadItemListener?.remove()
     this.completeListener?.remove()
     this.itemPartUpdateListener?.remove()
+    this.failureListener?.remove()
   }
 }
 </script>

--- a/ios/App/Shared/util/Database.swift
+++ b/ios/App/Shared/util/Database.swift
@@ -220,6 +220,16 @@ class Database {
         let realm = try Realm()
         return try realm.write { realm.add(downloadItem, update: .modified) }
     }
+
+    public func getAllDownloadItems() -> [DownloadItem] {
+        do {
+            let realm = try Realm()
+            return Array(realm.objects(DownloadItem.self))
+        } catch {
+            debugPrint(error)
+            return []
+        }
+    }
     
     public func getDeviceSettings() -> DeviceSettings {
         let realm = try! Realm()

--- a/pages/downloading.vue
+++ b/pages/downloading.vue
@@ -1,43 +1,97 @@
 <template>
   <div class="w-full h-full py-6 px-4 overflow-y-auto">
-    <p class="mb-4 text-base text-fg">{{ $strings.HeaderDownloads }} ({{ downloadItemParts.length }})</p>
+    <p class="mb-4 text-base text-fg">{{ $strings.HeaderDownloads }} ({{ downloadItems.length }})</p>
 
-    <div v-if="!downloadItemParts.length" class="py-6 text-center text-lg">No download item parts</div>
-    <template v-for="(itemPart, num) in downloadItemParts">
-      <div :key="itemPart.id" class="w-full">
-        <div class="flex">
-          <div class="w-14">
-            <span v-if="itemPart.completed" class="material-symbols text-success">check_circle</span>
-            <span v-else class="font-semibold text-fg">{{ Math.round(itemPart.progress) }}%</span>
-          </div>
-          <div class="flex-grow px-2">
-            <p class="truncate">{{ itemPart.filename }}</p>
-          </div>
+    <div v-if="!downloadItems.length" class="py-6 text-center text-lg text-fg-muted">
+      {{ $strings.MessageNoActiveDownloads }}
+    </div>
+
+    <div v-for="(item, index) in downloadItems" :key="item.id" class="pb-4">
+      <div class="flex items-start justify-between">
+        <div class="pr-4 flex-1 min-w-0">
+          <p class="text-sm font-medium text-fg truncate">{{ downloadTitle(item) }}</p>
+          <p class="text-xs mt-1" :class="item.failed ? 'text-error' : 'text-fg-muted'">
+            <template v-if="item.failed">
+              {{ $strings.LabelDownloadInterrupted }}
+            </template>
+            <template v-else>
+              {{ itemProgressPercent(item) }}%
+            </template>
+          </p>
         </div>
-
-        <div v-if="num + 1 < downloadItemParts.length" class="flex border-t border-border my-3" />
+        <button
+          v-if="item.failed"
+          class="px-3 py-1 text-xs font-semibold border border-accent text-accent rounded-full"
+          @click.stop="resumeDownload(item)"
+        >
+          {{ $strings.LabelRetry }}
+        </button>
       </div>
-    </template>
+
+      <div class="mt-3 space-y-2">
+        <div
+          v-for="part in item.downloadItemParts"
+          :key="part.id"
+          class="flex items-center justify-between text-xs"
+        >
+          <span class="truncate mr-4 text-fg-muted">{{ part.filename }}</span>
+          <span :class="partStatusClass(part)">{{ partStatus(part) }}</span>
+        </div>
+      </div>
+
+      <div v-if="index + 1 < downloadItems.length" class="border-t border-border mt-4 pt-4" />
+    </div>
   </div>
 </template>
 
 <script>
+import { AbsDownloader } from '@/plugins/capacitor'
+
 export default {
   data() {
     return {}
   },
   computed: {
     downloadItems() {
-      return this.$store.state.globals.itemDownloads
-    },
-    downloadItemParts() {
-      let parts = []
-      this.downloadItems.forEach((di) => parts.push(...di.downloadItemParts))
-      return parts
+      return this.$store.state.globals.itemDownloads || []
     }
   },
-  mounted() {},
-  beforeDestroy() {}
+  methods: {
+    downloadTitle(item) {
+      if (!item) return this.$strings.LabelDownload
+      return item.itemTitle || item.media?.metadata?.title || this.$strings.LabelDownload
+    },
+    itemProgressPercent(item) {
+      if (!item || typeof item.itemProgress !== 'number') return 0
+      const percent = Math.round(item.itemProgress * 100)
+      return Math.min(100, Math.max(0, percent))
+    },
+    partStatus(part) {
+      if (!part) return ''
+      if (part.failed) return this.$strings.LabelDownloadInterrupted
+      if (part.completed && !part.failed) return this.$strings.LabelDownloaded
+      const percent = Math.round(Number(part.progress) || 0)
+      return `${Math.min(100, Math.max(0, percent))}%`
+    },
+    partStatusClass(part) {
+      if (part?.failed) return 'text-error font-medium'
+      if (part?.completed && !part?.failed) return 'text-success'
+      return 'text-fg-muted'
+    },
+    async resumeDownload(item) {
+      if (!item?.id) return
+      try {
+        const res = await AbsDownloader.resumeDownload({ downloadItemId: item.id })
+        if (res && res.error) throw new Error(res.error)
+        const message = this.$getString('ToastDownloadResumed', [this.downloadTitle(item)])
+        this.$toast.success(message)
+      } catch (error) {
+        console.error('Failed to resume download', error)
+        const message = this.$getString('ToastDownloadInterrupted', [this.downloadTitle(item)]) || this.$strings.ToastDownloadInterrupted
+        this.$toast.error(message)
+      }
+    }
+  }
 }
 </script>
 

--- a/plugins/capacitor/AbsDownloader.js
+++ b/plugins/capacitor/AbsDownloader.js
@@ -4,6 +4,14 @@ class AbsDownloaderWeb extends WebPlugin {
   constructor() {
     super()
   }
+
+  async resumeDownload() {
+    return {}
+  }
+
+  async getDownloadQueue() {
+    return { items: [] }
+  }
 }
 
 const AbsDownloader = registerPlugin('AbsDownloader', {

--- a/store/globals.js
+++ b/store/globals.js
@@ -43,6 +43,15 @@ export const state = () => ({
   rssFeedEntity: null
 })
 
+const updateDownloadFlags = (downloadItem) => {
+  if (!downloadItem) return
+  if (Array.isArray(downloadItem.downloadItemParts)) {
+    downloadItem.failed = downloadItem.downloadItemParts.some((dip) => dip.failed)
+  } else {
+    downloadItem.failed = false
+  }
+}
+
 export const getters = {
   getDownloadItem:
     (state) =>
@@ -134,6 +143,7 @@ export const mutations = {
     state.isModalOpen = val
   },
   addUpdateItemDownload(state, downloadItem) {
+    updateDownloadFlags(downloadItem)
     var index = state.itemDownloads.findIndex((i) => i.id == downloadItem.id)
     if (index >= 0) {
       state.itemDownloads.splice(index, 1, downloadItem)
@@ -165,6 +175,7 @@ export const mutations = {
     } else {
       downloadItem.itemProgress = 0
     }
+    updateDownloadFlags(downloadItem)
   },
   removeItemDownload(state, id) {
     state.itemDownloads = state.itemDownloads.filter((i) => i.id != id)

--- a/strings/ar.json
+++ b/strings/ar.json
@@ -350,5 +350,10 @@
   "ToastPodcastCreateSuccess": "تم إنشاء البودكاست بنجاح",
   "ToastRSSFeedCloseFailed": "فشل إغلاق مغذّي RSS",
   "ToastRSSFeedCloseSuccess": "تم إغلاق مغذّي RSS",
-  "ToastStreamingNotAllowedOnCellular": "لا يُسمح بالبث عبر البيانات الخلوية"
+  "ToastStreamingNotAllowedOnCellular": "لا يُسمح بالبث عبر البيانات الخلوية",
+  "LabelDownloadInterrupted": "Download interrupted",
+  "LabelRetry": "Retry",
+  "MessageNoActiveDownloads": "No active downloads",
+  "ToastDownloadInterrupted": "Download interrupted for {0}. You can retry from the Downloads screen.",
+  "ToastDownloadResumed": "Restarted download for {0}."
 }

--- a/strings/be.json
+++ b/strings/be.json
@@ -355,5 +355,10 @@
   "ToastPodcastCreateSuccess": "Падкаст паспяхова створаны",
   "ToastRSSFeedCloseFailed": "Не ўдалося закрыць RSS-стужку",
   "ToastRSSFeedCloseSuccess": "RSS-стужка закрыта",
-  "ToastStreamingNotAllowedOnCellular": "Патокавая перадача праз мабільную сувязь забаронена"
+  "ToastStreamingNotAllowedOnCellular": "Патокавая перадача праз мабільную сувязь забаронена",
+  "LabelDownloadInterrupted": "Download interrupted",
+  "LabelRetry": "Retry",
+  "MessageNoActiveDownloads": "No active downloads",
+  "ToastDownloadInterrupted": "Download interrupted for {0}. You can retry from the Downloads screen.",
+  "ToastDownloadResumed": "Restarted download for {0}."
 }

--- a/strings/bg.json
+++ b/strings/bg.json
@@ -355,5 +355,10 @@
   "ToastPodcastCreateSuccess": "Подкаст успешно създаден",
   "ToastRSSFeedCloseFailed": "Неуспешно затваряне на RSS емисията",
   "ToastRSSFeedCloseSuccess": "RSS емисията е затворена",
-  "ToastStreamingNotAllowedOnCellular": "Стриймването не е разрешено чрез мобилни данни"
+  "ToastStreamingNotAllowedOnCellular": "Стриймването не е разрешено чрез мобилни данни",
+  "LabelDownloadInterrupted": "Download interrupted",
+  "LabelRetry": "Retry",
+  "MessageNoActiveDownloads": "No active downloads",
+  "ToastDownloadInterrupted": "Download interrupted for {0}. You can retry from the Downloads screen.",
+  "ToastDownloadResumed": "Restarted download for {0}."
 }

--- a/strings/bn.json
+++ b/strings/bn.json
@@ -323,5 +323,10 @@
   "ToastPodcastCreateSuccess": "পডকাস্ট সফলভাবে তৈরি করা হয়েছে",
   "ToastRSSFeedCloseFailed": "RSS ফিড বন্ধ করতে ব্যর্থ",
   "ToastRSSFeedCloseSuccess": "RSS ফিড বন্ধ",
-  "ToastStreamingNotAllowedOnCellular": "সেলুলার ডেটাতে স্ট্রিমিং অনুমোদিত নয়"
+  "ToastStreamingNotAllowedOnCellular": "সেলুলার ডেটাতে স্ট্রিমিং অনুমোদিত নয়",
+  "LabelDownloadInterrupted": "Download interrupted",
+  "LabelRetry": "Retry",
+  "MessageNoActiveDownloads": "No active downloads",
+  "ToastDownloadInterrupted": "Download interrupted for {0}. You can retry from the Downloads screen.",
+  "ToastDownloadResumed": "Restarted download for {0}."
 }

--- a/strings/ca.json
+++ b/strings/ca.json
@@ -279,5 +279,10 @@
   "ToastPodcastCreateFailed": "No s'ha pogut crear el pòdcast",
   "ToastPodcastCreateSuccess": "S'ha creat el pòdcast correctament",
   "ToastRSSFeedCloseFailed": "No s'ha pogut tancar el canal RSS",
-  "ToastRSSFeedCloseSuccess": "Canal RSS tancat"
+  "ToastRSSFeedCloseSuccess": "Canal RSS tancat",
+  "LabelDownloadInterrupted": "Download interrupted",
+  "LabelRetry": "Retry",
+  "MessageNoActiveDownloads": "No active downloads",
+  "ToastDownloadInterrupted": "Download interrupted for {0}. You can retry from the Downloads screen.",
+  "ToastDownloadResumed": "Restarted download for {0}."
 }

--- a/strings/cs.json
+++ b/strings/cs.json
@@ -355,5 +355,10 @@
   "ToastPodcastCreateSuccess": "Podcast byl úspěšně vytvořen",
   "ToastRSSFeedCloseFailed": "Nepodařilo se zavřít RSS kanál",
   "ToastRSSFeedCloseSuccess": "RSS kanál uzavřen",
-  "ToastStreamingNotAllowedOnCellular": "Přehrávání přes mobilní data není povoleno"
+  "ToastStreamingNotAllowedOnCellular": "Přehrávání přes mobilní data není povoleno",
+  "LabelDownloadInterrupted": "Download interrupted",
+  "LabelRetry": "Retry",
+  "MessageNoActiveDownloads": "No active downloads",
+  "ToastDownloadInterrupted": "Download interrupted for {0}. You can retry from the Downloads screen.",
+  "ToastDownloadResumed": "Restarted download for {0}."
 }

--- a/strings/da.json
+++ b/strings/da.json
@@ -354,5 +354,10 @@
   "ToastPodcastCreateSuccess": "Podcast oprettet med succes",
   "ToastRSSFeedCloseFailed": "Mislykkedes lukning af RSS-feed",
   "ToastRSSFeedCloseSuccess": "RSS-feed lukket",
-  "ToastStreamingNotAllowedOnCellular": "Det er ikke tillad at streame over mobildata"
+  "ToastStreamingNotAllowedOnCellular": "Det er ikke tillad at streame over mobildata",
+  "LabelDownloadInterrupted": "Download interrupted",
+  "LabelRetry": "Retry",
+  "MessageNoActiveDownloads": "No active downloads",
+  "ToastDownloadInterrupted": "Download interrupted for {0}. You can retry from the Downloads screen.",
+  "ToastDownloadResumed": "Restarted download for {0}."
 }

--- a/strings/de.json
+++ b/strings/de.json
@@ -355,5 +355,10 @@
   "ToastPodcastCreateSuccess": "Podcast erstellt",
   "ToastRSSFeedCloseFailed": "RSS-Feed konnte nicht geschlossen werden",
   "ToastRSSFeedCloseSuccess": "RSS-Feed geschlossen",
-  "ToastStreamingNotAllowedOnCellular": "Das Streamen über mobile Daten ist nicht erlaubt"
+  "ToastStreamingNotAllowedOnCellular": "Das Streamen über mobile Daten ist nicht erlaubt",
+  "LabelDownloadInterrupted": "Download interrupted",
+  "LabelRetry": "Retry",
+  "MessageNoActiveDownloads": "No active downloads",
+  "ToastDownloadInterrupted": "Download interrupted for {0}. You can retry from the Downloads screen.",
+  "ToastDownloadResumed": "Restarted download for {0}."
 }

--- a/strings/en-us.json
+++ b/strings/en-us.json
@@ -355,5 +355,10 @@
   "ToastPodcastCreateSuccess": "Podcast created successfully",
   "ToastRSSFeedCloseFailed": "Failed to close RSS feed",
   "ToastRSSFeedCloseSuccess": "RSS feed closed",
-  "ToastStreamingNotAllowedOnCellular": "Streaming is not allowed on cellular data"
+  "ToastStreamingNotAllowedOnCellular": "Streaming is not allowed on cellular data",
+  "LabelDownloadInterrupted": "Download interrupted",
+  "LabelRetry": "Retry",
+  "MessageNoActiveDownloads": "No active downloads",
+  "ToastDownloadInterrupted": "Download interrupted for {0}. You can retry from the Downloads screen.",
+  "ToastDownloadResumed": "Restarted download for {0}."
 }

--- a/strings/es.json
+++ b/strings/es.json
@@ -350,5 +350,10 @@
   "ToastPodcastCreateSuccess": "Se creó el pódcast correctamente",
   "ToastRSSFeedCloseFailed": "Error al cerrar el suministro RSS",
   "ToastRSSFeedCloseSuccess": "Suministro RSS cerrado",
-  "ToastStreamingNotAllowedOnCellular": "El streaming no está permitido con datos móviles"
+  "ToastStreamingNotAllowedOnCellular": "El streaming no está permitido con datos móviles",
+  "LabelDownloadInterrupted": "Download interrupted",
+  "LabelRetry": "Retry",
+  "MessageNoActiveDownloads": "No active downloads",
+  "ToastDownloadInterrupted": "Download interrupted for {0}. You can retry from the Downloads screen.",
+  "ToastDownloadResumed": "Restarted download for {0}."
 }

--- a/strings/et.json
+++ b/strings/et.json
@@ -173,5 +173,10 @@
   "LabelTitle": "Pealkiri",
   "LabelTotalSize": "Kogusuurus",
   "LabelType": "Tüüp",
-  "LabelUnknown": "Teadmata"
+  "LabelUnknown": "Teadmata",
+  "LabelDownloadInterrupted": "Download interrupted",
+  "LabelRetry": "Retry",
+  "MessageNoActiveDownloads": "No active downloads",
+  "ToastDownloadInterrupted": "Download interrupted for {0}. You can retry from the Downloads screen.",
+  "ToastDownloadResumed": "Restarted download for {0}."
 }

--- a/strings/fi.json
+++ b/strings/fi.json
@@ -343,5 +343,10 @@
   "ToastPodcastCreateSuccess": "Podcastin luominen onnistui",
   "ToastRSSFeedCloseFailed": "RSS syötteen sulkeminen epäonnistui",
   "ToastRSSFeedCloseSuccess": "RSS syöte suljettu",
-  "ToastStreamingNotAllowedOnCellular": "Suoratoisto ei ole sallittu mobiilidatalla"
+  "ToastStreamingNotAllowedOnCellular": "Suoratoisto ei ole sallittu mobiilidatalla",
+  "LabelDownloadInterrupted": "Download interrupted",
+  "LabelRetry": "Retry",
+  "MessageNoActiveDownloads": "No active downloads",
+  "ToastDownloadInterrupted": "Download interrupted for {0}. You can retry from the Downloads screen.",
+  "ToastDownloadResumed": "Restarted download for {0}."
 }

--- a/strings/fr.json
+++ b/strings/fr.json
@@ -355,5 +355,10 @@
   "ToastPodcastCreateSuccess": "Podcast créé avec succès",
   "ToastRSSFeedCloseFailed": "Échec de la fermeture du flux RSS",
   "ToastRSSFeedCloseSuccess": "Flux RSS fermé",
-  "ToastStreamingNotAllowedOnCellular": "La diffusion sur les données mobile n’est pas autorisée"
+  "ToastStreamingNotAllowedOnCellular": "La diffusion sur les données mobile n’est pas autorisée",
+  "LabelDownloadInterrupted": "Download interrupted",
+  "LabelRetry": "Retry",
+  "MessageNoActiveDownloads": "No active downloads",
+  "ToastDownloadInterrupted": "Download interrupted for {0}. You can retry from the Downloads screen.",
+  "ToastDownloadResumed": "Restarted download for {0}."
 }

--- a/strings/gu.json
+++ b/strings/gu.json
@@ -33,5 +33,10 @@
   "LabelStartTime": "Start Time",
   "MessageFollowTheProjectOnGithub": "Follow the project on GitHub",
   "MessageSocketConnectedOverMeteredWifi": "Socket connected over metered Wi-Fi",
-  "MessageSocketConnectedOverUnmeteredWifi": "Socket connected over unmetered Wi-Fi"
+  "MessageSocketConnectedOverUnmeteredWifi": "Socket connected over unmetered Wi-Fi",
+  "LabelDownloadInterrupted": "Download interrupted",
+  "LabelRetry": "Retry",
+  "MessageNoActiveDownloads": "No active downloads",
+  "ToastDownloadInterrupted": "Download interrupted for {0}. You can retry from the Downloads screen.",
+  "ToastDownloadResumed": "Restarted download for {0}."
 }

--- a/strings/he.json
+++ b/strings/he.json
@@ -349,5 +349,10 @@
   "ToastPodcastCreateSuccess": "הפודקאסט נוצר בהצלחה",
   "ToastRSSFeedCloseFailed": "סגירת ערוץ ה-RSS נכשלה",
   "ToastRSSFeedCloseSuccess": "ערוץ ה-RSS נסגר בהצלחה",
-  "ToastStreamingNotAllowedOnCellular": "הזרמה אינה מותרת באמצעות נתונים סלולריים"
+  "ToastStreamingNotAllowedOnCellular": "הזרמה אינה מותרת באמצעות נתונים סלולריים",
+  "LabelDownloadInterrupted": "Download interrupted",
+  "LabelRetry": "Retry",
+  "MessageNoActiveDownloads": "No active downloads",
+  "ToastDownloadInterrupted": "Download interrupted for {0}. You can retry from the Downloads screen.",
+  "ToastDownloadResumed": "Restarted download for {0}."
 }

--- a/strings/hi.json
+++ b/strings/hi.json
@@ -48,5 +48,10 @@
   "LabelStartTime": "Start Time",
   "MessageFollowTheProjectOnGithub": "Follow the project on GitHub",
   "MessageSocketConnectedOverMeteredWifi": "Socket connected over metered Wi-Fi",
-  "MessageSocketConnectedOverUnmeteredWifi": "Socket connected over unmetered Wi-Fi"
+  "MessageSocketConnectedOverUnmeteredWifi": "Socket connected over unmetered Wi-Fi",
+  "LabelDownloadInterrupted": "Download interrupted",
+  "LabelRetry": "Retry",
+  "MessageNoActiveDownloads": "No active downloads",
+  "ToastDownloadInterrupted": "Download interrupted for {0}. You can retry from the Downloads screen.",
+  "ToastDownloadResumed": "Restarted download for {0}."
 }

--- a/strings/hr.json
+++ b/strings/hr.json
@@ -355,5 +355,10 @@
   "ToastPodcastCreateSuccess": "Podcast uspješno izrađen",
   "ToastRSSFeedCloseFailed": "RSS izvor nije uspješno zatvoren",
   "ToastRSSFeedCloseSuccess": "RSS izvor zatvoren",
-  "ToastStreamingNotAllowedOnCellular": "Strujanje korištenjem mobilnih podataka onemogućeno je"
+  "ToastStreamingNotAllowedOnCellular": "Strujanje korištenjem mobilnih podataka onemogućeno je",
+  "LabelDownloadInterrupted": "Download interrupted",
+  "LabelRetry": "Retry",
+  "MessageNoActiveDownloads": "No active downloads",
+  "ToastDownloadInterrupted": "Download interrupted for {0}. You can retry from the Downloads screen.",
+  "ToastDownloadResumed": "Restarted download for {0}."
 }

--- a/strings/hu.json
+++ b/strings/hu.json
@@ -355,5 +355,10 @@
   "ToastPodcastCreateSuccess": "A podcast sikeresen létrehozva",
   "ToastRSSFeedCloseFailed": "Az RSS hírcsatorna bezárása sikertelen",
   "ToastRSSFeedCloseSuccess": "Az RSS hírcsatorna sikeresen bezárva",
-  "ToastStreamingNotAllowedOnCellular": "Streamelés mobilinternettel nem engedélyezett"
+  "ToastStreamingNotAllowedOnCellular": "Streamelés mobilinternettel nem engedélyezett",
+  "LabelDownloadInterrupted": "Download interrupted",
+  "LabelRetry": "Retry",
+  "MessageNoActiveDownloads": "No active downloads",
+  "ToastDownloadInterrupted": "Download interrupted for {0}. You can retry from the Downloads screen.",
+  "ToastDownloadResumed": "Restarted download for {0}."
 }

--- a/strings/it.json
+++ b/strings/it.json
@@ -354,5 +354,10 @@
   "ToastPodcastCreateSuccess": "Podcast creato correttamente",
   "ToastRSSFeedCloseFailed": "Errore chiusura flusso RSS",
   "ToastRSSFeedCloseSuccess": "Flusso RSS chiuso",
-  "ToastStreamingNotAllowedOnCellular": "Lo streaming non è consentito sui dati mobili"
+  "ToastStreamingNotAllowedOnCellular": "Lo streaming non è consentito sui dati mobili",
+  "LabelDownloadInterrupted": "Download interrupted",
+  "LabelRetry": "Retry",
+  "MessageNoActiveDownloads": "No active downloads",
+  "ToastDownloadInterrupted": "Download interrupted for {0}. You can retry from the Downloads screen.",
+  "ToastDownloadResumed": "Restarted download for {0}."
 }

--- a/strings/ja.json
+++ b/strings/ja.json
@@ -160,5 +160,10 @@
   "LabelPodcast": "ポッドキャスト",
   "LabelPodcasts": "ポッドキャスト",
   "LabelPreventIndexing": "フィードがiTunesおよびGoogleのポッドキャストディレクトリにインデックス登録されるのを防ぎます",
-  "LabelPublishYear": "公開年"
+  "LabelPublishYear": "公開年",
+  "LabelDownloadInterrupted": "Download interrupted",
+  "LabelRetry": "Retry",
+  "MessageNoActiveDownloads": "No active downloads",
+  "ToastDownloadInterrupted": "Download interrupted for {0}. You can retry from the Downloads screen.",
+  "ToastDownloadResumed": "Restarted download for {0}."
 }

--- a/strings/lt.json
+++ b/strings/lt.json
@@ -183,5 +183,10 @@
   "ToastPodcastCreateFailed": "Tinklalaidės sukurti nepavyko",
   "ToastPodcastCreateSuccess": "Tinklalaidė sėkmingai sukurta",
   "ToastRSSFeedCloseFailed": "RSS srauto uždaryti nepavyko",
-  "ToastRSSFeedCloseSuccess": "RSS srautas uždarytas"
+  "ToastRSSFeedCloseSuccess": "RSS srautas uždarytas",
+  "LabelDownloadInterrupted": "Download interrupted",
+  "LabelRetry": "Retry",
+  "MessageNoActiveDownloads": "No active downloads",
+  "ToastDownloadInterrupted": "Download interrupted for {0}. You can retry from the Downloads screen.",
+  "ToastDownloadResumed": "Restarted download for {0}."
 }

--- a/strings/nl.json
+++ b/strings/nl.json
@@ -355,5 +355,10 @@
   "ToastPodcastCreateSuccess": "Podcast aangemaakt",
   "ToastRSSFeedCloseFailed": "Sluiten RSS-feed mislukt",
   "ToastRSSFeedCloseSuccess": "RSS-feed gesloten",
-  "ToastStreamingNotAllowedOnCellular": "Streamen is niet toegstaan via mobiele verbinding"
+  "ToastStreamingNotAllowedOnCellular": "Streamen is niet toegstaan via mobiele verbinding",
+  "LabelDownloadInterrupted": "Download interrupted",
+  "LabelRetry": "Retry",
+  "MessageNoActiveDownloads": "No active downloads",
+  "ToastDownloadInterrupted": "Download interrupted for {0}. You can retry from the Downloads screen.",
+  "ToastDownloadResumed": "Restarted download for {0}."
 }

--- a/strings/no.json
+++ b/strings/no.json
@@ -354,5 +354,10 @@
   "ToastPodcastCreateSuccess": "Podcast opprettet",
   "ToastRSSFeedCloseFailed": "Misslykkes å lukke RSS feed",
   "ToastRSSFeedCloseSuccess": "RSS feed lukket",
-  "ToastStreamingNotAllowedOnCellular": "Strømming tillates ikke over mobildata"
+  "ToastStreamingNotAllowedOnCellular": "Strømming tillates ikke over mobildata",
+  "LabelDownloadInterrupted": "Download interrupted",
+  "LabelRetry": "Retry",
+  "MessageNoActiveDownloads": "No active downloads",
+  "ToastDownloadInterrupted": "Download interrupted for {0}. You can retry from the Downloads screen.",
+  "ToastDownloadResumed": "Restarted download for {0}."
 }

--- a/strings/pl.json
+++ b/strings/pl.json
@@ -353,5 +353,10 @@
   "ToastPodcastCreateSuccess": "Podcast został pomyślnie utworzony",
   "ToastRSSFeedCloseFailed": "Zamknięcie kanału RSS nie powiodło się",
   "ToastRSSFeedCloseSuccess": "Zamknięcie kanału RSS powiodło się",
-  "ToastStreamingNotAllowedOnCellular": "Transmisja nie jest dozwolona w przy użyciu danych komórkowych"
+  "ToastStreamingNotAllowedOnCellular": "Transmisja nie jest dozwolona w przy użyciu danych komórkowych",
+  "LabelDownloadInterrupted": "Download interrupted",
+  "LabelRetry": "Retry",
+  "MessageNoActiveDownloads": "No active downloads",
+  "ToastDownloadInterrupted": "Download interrupted for {0}. You can retry from the Downloads screen.",
+  "ToastDownloadResumed": "Restarted download for {0}."
 }

--- a/strings/pt-br.json
+++ b/strings/pt-br.json
@@ -304,5 +304,10 @@
   "ToastPodcastCreateSuccess": "Podcast criado",
   "ToastRSSFeedCloseFailed": "Falha ao fechar feed RSS",
   "ToastRSSFeedCloseSuccess": "Feed RSS fechado",
-  "ToastStreamingNotAllowedOnCellular": "Streaming não é permitido usando dados do celular"
+  "ToastStreamingNotAllowedOnCellular": "Streaming não é permitido usando dados do celular",
+  "LabelDownloadInterrupted": "Download interrupted",
+  "LabelRetry": "Retry",
+  "MessageNoActiveDownloads": "No active downloads",
+  "ToastDownloadInterrupted": "Download interrupted for {0}. You can retry from the Downloads screen.",
+  "ToastDownloadResumed": "Restarted download for {0}."
 }

--- a/strings/ro.json
+++ b/strings/ro.json
@@ -355,5 +355,10 @@
   "ToastPodcastCreateSuccess": "Podcast creat cu succes",
   "ToastRSSFeedCloseFailed": "Nu s-a putut închide fluxul RSS",
   "ToastRSSFeedCloseSuccess": "Flux RSS închis",
-  "ToastStreamingNotAllowedOnCellular": "Redarea online nu este permisă pe date mobile"
+  "ToastStreamingNotAllowedOnCellular": "Redarea online nu este permisă pe date mobile",
+  "LabelDownloadInterrupted": "Download interrupted",
+  "LabelRetry": "Retry",
+  "MessageNoActiveDownloads": "No active downloads",
+  "ToastDownloadInterrupted": "Download interrupted for {0}. You can retry from the Downloads screen.",
+  "ToastDownloadResumed": "Restarted download for {0}."
 }

--- a/strings/ru.json
+++ b/strings/ru.json
@@ -355,5 +355,10 @@
   "ToastPodcastCreateSuccess": "Подкаст успешно создан",
   "ToastRSSFeedCloseFailed": "Не удалось закрыть RSS-ленту",
   "ToastRSSFeedCloseSuccess": "RSS-лента закрыта",
-  "ToastStreamingNotAllowedOnCellular": "Потоковая передача данных по сотовой сети запрещена"
+  "ToastStreamingNotAllowedOnCellular": "Потоковая передача данных по сотовой сети запрещена",
+  "LabelDownloadInterrupted": "Download interrupted",
+  "LabelRetry": "Retry",
+  "MessageNoActiveDownloads": "No active downloads",
+  "ToastDownloadInterrupted": "Download interrupted for {0}. You can retry from the Downloads screen.",
+  "ToastDownloadResumed": "Restarted download for {0}."
 }

--- a/strings/sk.json
+++ b/strings/sk.json
@@ -355,5 +355,10 @@
   "ToastPodcastCreateSuccess": "Podcast bol vytvorený",
   "ToastRSSFeedCloseFailed": "Odstránenie RSS zdroja zlyhalo",
   "ToastRSSFeedCloseSuccess": "RSS zdroj bol odstránený",
-  "ToastStreamingNotAllowedOnCellular": "Streamovanie cez mobilné dáta nie je povolené"
+  "ToastStreamingNotAllowedOnCellular": "Streamovanie cez mobilné dáta nie je povolené",
+  "LabelDownloadInterrupted": "Download interrupted",
+  "LabelRetry": "Retry",
+  "MessageNoActiveDownloads": "No active downloads",
+  "ToastDownloadInterrupted": "Download interrupted for {0}. You can retry from the Downloads screen.",
+  "ToastDownloadResumed": "Restarted download for {0}."
 }

--- a/strings/sl.json
+++ b/strings/sl.json
@@ -355,5 +355,10 @@
   "ToastPodcastCreateSuccess": "Podcast je bil uspešno ustvarjen",
   "ToastRSSFeedCloseFailed": "Vira RSS ni bilo mogoče zapreti",
   "ToastRSSFeedCloseSuccess": "Vir RSS je bil zaprt",
-  "ToastStreamingNotAllowedOnCellular": "Pretakanje ni dovoljeno na mobilnih podatkih"
+  "ToastStreamingNotAllowedOnCellular": "Pretakanje ni dovoljeno na mobilnih podatkih",
+  "LabelDownloadInterrupted": "Download interrupted",
+  "LabelRetry": "Retry",
+  "MessageNoActiveDownloads": "No active downloads",
+  "ToastDownloadInterrupted": "Download interrupted for {0}. You can retry from the Downloads screen.",
+  "ToastDownloadResumed": "Restarted download for {0}."
 }

--- a/strings/sv.json
+++ b/strings/sv.json
@@ -354,5 +354,10 @@
   "ToastPodcastCreateSuccess": "Podcasten skapades framgångsrikt",
   "ToastRSSFeedCloseFailed": "Misslyckades med att stänga RSS-flödet",
   "ToastRSSFeedCloseSuccess": "RSS-flödet stängt",
-  "ToastStreamingNotAllowedOnCellular": "Strömning tillåts inte över mobildata."
+  "ToastStreamingNotAllowedOnCellular": "Strömning tillåts inte över mobildata.",
+  "LabelDownloadInterrupted": "Download interrupted",
+  "LabelRetry": "Retry",
+  "MessageNoActiveDownloads": "No active downloads",
+  "ToastDownloadInterrupted": "Download interrupted for {0}. You can retry from the Downloads screen.",
+  "ToastDownloadResumed": "Restarted download for {0}."
 }

--- a/strings/tr.json
+++ b/strings/tr.json
@@ -273,5 +273,10 @@
   "MessageAttemptingServerConnection": "Sunucusu bağlantısı deneniyor...",
   "MessageAudiobookshelfServerNotConnected": "Audiobookshelf sunucusu bağlı değil",
   "MessageAudiobookshelfServerRequired": "<strong>Önemli!</strong> Bu uygulama sizin ya da tanıdığınız birinin hostladığı bir Audiobookshelf sunucusu ile birlikte çalışması için tasarlanmıştır. Bu uygulama herhangi bir içerik sunmaz.",
-  "MessageBookshelfEmpty": "Kitaplık boş"
+  "MessageBookshelfEmpty": "Kitaplık boş",
+  "LabelDownloadInterrupted": "Download interrupted",
+  "LabelRetry": "Retry",
+  "MessageNoActiveDownloads": "No active downloads",
+  "ToastDownloadInterrupted": "Download interrupted for {0}. You can retry from the Downloads screen.",
+  "ToastDownloadResumed": "Restarted download for {0}."
 }

--- a/strings/uk.json
+++ b/strings/uk.json
@@ -355,5 +355,10 @@
   "ToastPodcastCreateSuccess": "Подкаст успішно створено",
   "ToastRSSFeedCloseFailed": "Не вдалося закрити RSS-канал",
   "ToastRSSFeedCloseSuccess": "RSS-канал закрито",
-  "ToastStreamingNotAllowedOnCellular": "Трансляція через мобільний інтернет заборонена"
+  "ToastStreamingNotAllowedOnCellular": "Трансляція через мобільний інтернет заборонена",
+  "LabelDownloadInterrupted": "Download interrupted",
+  "LabelRetry": "Retry",
+  "MessageNoActiveDownloads": "No active downloads",
+  "ToastDownloadInterrupted": "Download interrupted for {0}. You can retry from the Downloads screen.",
+  "ToastDownloadResumed": "Restarted download for {0}."
 }

--- a/strings/vi-vn.json
+++ b/strings/vi-vn.json
@@ -315,5 +315,10 @@
   "ToastPodcastCreateFailed": "Không thể tạo podcast",
   "ToastPodcastCreateSuccess": "Tạo podcast thành công",
   "ToastRSSFeedCloseFailed": "Không thể đóng RSS feed",
-  "ToastRSSFeedCloseSuccess": "Đóng RSS feed thành công"
+  "ToastRSSFeedCloseSuccess": "Đóng RSS feed thành công",
+  "LabelDownloadInterrupted": "Download interrupted",
+  "LabelRetry": "Retry",
+  "MessageNoActiveDownloads": "No active downloads",
+  "ToastDownloadInterrupted": "Download interrupted for {0}. You can retry from the Downloads screen.",
+  "ToastDownloadResumed": "Restarted download for {0}."
 }

--- a/strings/zh-cn.json
+++ b/strings/zh-cn.json
@@ -355,5 +355,10 @@
   "ToastPodcastCreateSuccess": "已成功创建播客",
   "ToastRSSFeedCloseFailed": "关闭 RSS 源失败",
   "ToastRSSFeedCloseSuccess": "RSS 源已关闭",
-  "ToastStreamingNotAllowedOnCellular": "不允许通过移动数据进行流媒体播放"
+  "ToastStreamingNotAllowedOnCellular": "不允许通过移动数据进行流媒体播放",
+  "LabelDownloadInterrupted": "Download interrupted",
+  "LabelRetry": "Retry",
+  "MessageNoActiveDownloads": "No active downloads",
+  "ToastDownloadInterrupted": "Download interrupted for {0}. You can retry from the Downloads screen.",
+  "ToastDownloadResumed": "Restarted download for {0}."
 }

--- a/strings/zh_Hant.json
+++ b/strings/zh_Hant.json
@@ -310,5 +310,10 @@
   "ToastPodcastCreateSuccess": "已成功創建播客",
   "ToastRSSFeedCloseFailed": "關閉 RSS 源失敗",
   "ToastRSSFeedCloseSuccess": "RSS 源已關閉",
-  "ToastStreamingNotAllowedOnCellular": "行動數據下不允許串流播放"
+  "ToastStreamingNotAllowedOnCellular": "行動數據下不允許串流播放",
+  "LabelDownloadInterrupted": "Download interrupted",
+  "LabelRetry": "Retry",
+  "MessageNoActiveDownloads": "No active downloads",
+  "ToastDownloadInterrupted": "Download interrupted for {0}. You can retry from the Downloads screen.",
+  "ToastDownloadResumed": "Restarted download for {0}."
 }


### PR DESCRIPTION
## Summary
- add failure tracking, cleanup, and resume support to the Android download manager and plugin while restoring queued downloads on load
- mirror the failure and resume capabilities in the iOS downloader and expose the download queue to the web layer
- surface failed downloads in the UI with retry controls, synchronize active downloads on startup, and add supporting store logic and strings

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e49e5b2324832889e5bccd8cf6c511